### PR TITLE
Drop knex 0.95

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
           - 'lts/-1'
           - 'lts/-2'
         knex:
-          - '^0.95.0'
           - '^1.0.0'
           - '^2.0.0'
     name: Build and test (Node ${{ matrix.node }}, knex ${{ matrix.knex }})

--- a/lib/knex.ts
+++ b/lib/knex.ts
@@ -22,7 +22,7 @@ interface KnexQuery {
     sql: string;
 }
 
-const supportedVersions = ['^0.95.0', '^1.0.0', '^2.0.0'];
+const supportedVersions = ['^1.0.0', '^2.0.0'];
 
 const _STORED_PARENT_SPAN = Symbol.for('opentelemetry.stored-parent-span');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "^4.1.3"
       },
       "peerDependencies": {
-        "knex": "^0.95.0 || ^1.0.0 || ^2.0.0"
+        "knex": "^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "peerDependencies": {
-    "knex": "^0.95.0 || ^1.0.0 || ^2.0.0"
+    "knex": "^1.0.0 || ^2.0.0"
   },
   "main": "dist/lib/index.js",
   "repository": {


### PR DESCRIPTION
TypeScript checks fail on knex 0.95.

```
Error: node_modules/knex/types/index.d.ts(206,51): error TS2344: Type 'T' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(283,54): error TS2344: Type 'TIntersectProps2' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(340,24): error TS2344: Type 'TRecord2' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(370,[30](https://github.com/myrotvorets/opentelemetry-plugin-knex/actions/runs/3644731600/jobs/6154250126#step:10:32)): error TS2344: Type 'TRecord2' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(374,5): error TS2344: Type 'TRecord2' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(4[32](https://github.com/myrotvorets/opentelemetry-plugin-knex/actions/runs/3644731600/jobs/6154250126#step:10:34),25): error TS2344: Type 'TRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(477,28): error TS2344: Type 'TRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(478,59): error TS2[34](https://github.com/myrotvorets/opentelemetry-plugin-knex/actions/runs/3644731600/jobs/6154250126#step:10:36)4: Type 'TRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(479,96): error TS2344: Type 'TRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(492,39): error TS2344: Type 'TResult' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(493,26): error TS2344: Type 'TResult' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(494,26): error TS2344: Type 'TResult' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(495,27): error TS2344: Type 'TResult' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(1013,47): error TS2344: Type 'TRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(1014,[40](https://github.com/myrotvorets/opentelemetry-plugin-knex/actions/runs/3644731600/jobs/6154250126#step:10:42)): error TS2344: Type 'TRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(1086,50): error TS2344: Type 'TInnerRecord' does not satisfy the constraint '{}'.
Error: node_modules/knex/types/index.d.ts(1090,47): error TS23[44](https://github.com/myrotvorets/opentelemetry-plugin-knex/actions/runs/3644731600/jobs/6154250126#step:10:46): Type 'TInnerRecord' does not satisfy the constraint '{}'.
...
```
